### PR TITLE
Fixed error in win_statistics where we didn't actually switch P1 with P2

### DIFF
--- a/tutorials/W1_AlphaZero/W1_Tutorial1.ipynb
+++ b/tutorials/W1_AlphaZero/W1_Tutorial1.ipynb
@@ -436,7 +436,7 @@
         "    outcome1, _ = ai_vs_ai(agent1, agent2, n_games=games_per_side//2, \n",
         "                          n=6)\n",
         "    # Play agent1 as player 2\n",
-        "    outcome2, _ = ai_vs_ai(agent1, agent2, n_games=games_per_side//2, \n",
+        "    outcome2, _ = ai_vs_ai(agent2, agent1, n_games=games_per_side//2, \n",
         "                          n=6)\n",
         "    outcome = torch.cat((outcome1,outcome2),dim=0) \n",
         "    for g in range(games_per_side):\n",

--- a/tutorials/W1_AlphaZero/student/W1_Tutorial1.ipynb
+++ b/tutorials/W1_AlphaZero/student/W1_Tutorial1.ipynb
@@ -436,7 +436,7 @@
         "    outcome1, _ = ai_vs_ai(agent1, agent2, n_games=games_per_side//2, \n",
         "                          n=6)\n",
         "    # Play agent1 as player 2\n",
-        "    outcome2, _ = ai_vs_ai(agent1, agent2, n_games=games_per_side//2, \n",
+        "    outcome2, _ = ai_vs_ai(agent2, agent1, n_games=games_per_side//2, \n",
         "                          n=6)\n",
         "    outcome = torch.cat((outcome1,outcome2),dim=0) \n",
         "    for g in range(games_per_side):\n",


### PR DESCRIPTION
In `win_statistics` it erroneously read:
```
# Play agent1 as player 1
outcome1, _ = ai_vs_ai(agent1, agent2, n_games=games_per_side//2, 
                      n=6)
# Play agent1 as player 2
outcome2, _ = ai_vs_ai(agent1, agent2, n_games=games_per_side//2, 
                      n=6)
```

Fixed so we actually switched the agents