### PR TITLE
Kelson's suggestions + a few more

### DIFF
--- a/tutorials/W1_AlphaZero/W1_Tutorial2.ipynb
+++ b/tutorials/W1_AlphaZero/W1_Tutorial2.ipynb
@@ -3931,20 +3931,18 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "fC2gXPxx1I9_"
+        "id": "fC2gXPxx1I9_",
+        "cellView": "form"
       },
       "source": [
-        "#markdown (RUN ME) See alignment of policy to MCTS visit counts in a test game\n",
-        "# pol_val_net.eval()\n",
-        "# alpha_zero_agent = MCTSagent_from_net(pol_val_net, n, 100, 20)\n",
-        "# alpha_zero_agent.temperature = 0.1\n",
-        "# outcomes, raw_states, raw_mcts_counts = ai_vs_ai(alpha_zero_agent, n_games=100,\n",
-        "#                                                  n=n, callback=mcts_visits_callback)\n",
-        "\n",
+        "#@markdown (RUN ME) See alignment of policy to MCTS visit counts in a test game\n",
+        "pol_val_net.eval()\n",
+        "alpha_zero_agent = MCTSagent_from_net(pol_val_net, n, 100, 20)\n",
+        "alpha_zero_agent.temperature = 0.1\n",
+        "outcomes, raw_states, raw_mcts_counts = ai_vs_ai(alpha_zero_agent, n_games=100,\n",
+        "                                                 n=n, callback=mcts_visits_callback)\n",
         "plt.figure(figsize=(10,5))\n",
         "ax1, ax2 = plt.subplot(1,2,1), plt.subplot(1,2,2)\n",
-        "policy_targets = []\n",
-        "policy_pred = []\n",
         "for t in range(len(raw_states)):\n",
         "    sgn = +1 if t % 2 == 0 else -1\n",
         "    player = 1 if t % 2 == 0 else 2\n",
@@ -3952,18 +3950,14 @@
         "    counts_t = raw_mcts_counts[t].view(-1, n*n)\n",
         "    targets_t = counts_t / counts_t.sum(dim=1, keepdim=True)\n",
         "    valid = ~torch.any(torch.isnan(raw_states[t][:,0,0]))\n",
-        "    policy_targets += list(targets_t[valid,...].cpu().T)\n",
-        "    policy_pred += list(pol_pred[valid,...].detach().exp().view(-1, n*n).cpu().T)\n",
-        "\n",
-        "ax1.scatter(policy_targets, policy_pred,\n",
-        "            marker='.', alpha = .5)\n",
-        "    # for g in range(len(raw_states)):\n",
-        "    #     if not torch.isnan(raw_states[t][g,0,0]):\n",
-        "    #         ax2.plot(t, val_pred[g].item(), marker='.', \n",
-        "    #                  color=outcome2color(outcomes[g,player-1], 0.25),\n",
-        "    #                  alpha = .2)\n",
-        "    #     break\n",
-        "            # ax2.plot(t, -val_pred[g].item(), marker='.', color=outcome2color(outcomes[g,2-player], 0.25))\n",
+        "    ax1.scatter(targets_t[valid,...].cpu().T, \n",
+        "                pol_pred[valid,...].detach().exp().view(-1, n*n).cpu().T, \n",
+        "                marker='.', c = 'k', alpha=.1)\n",
+        "    for g in range(len(raw_states)):\n",
+        "        if not torch.isnan(raw_states[t][g,0,0]):\n",
+        "            ax2.plot(t, val_pred[g].item(), marker='.', \n",
+        "                      color=outcome2color(outcomes[g,player-1], 0.25))\n",
+        "  \n",
         "ax1.set_xlabel('normalized MCTS visit counts')\n",
         "ax1.set_ylabel('policy net output')\n",
         "ax1.set_title('Policy Net Predictions')\n",
@@ -3971,17 +3965,6 @@
         "ax2.set_ylabel('Value Net Output')\n",
         "ax2.set_title('Value Net Predictions')\n",
         "plt.show()"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "s8s9_YJ3MS7V"
-      },
-      "source": [
-        "targets_t[valid,...].cpu().T"
       ],
       "execution_count": null,
       "outputs": []

--- a/tutorials/W1_AlphaZero/W1_Tutorial2.ipynb
+++ b/tutorials/W1_AlphaZero/W1_Tutorial2.ipynb
@@ -83,7 +83,7 @@
       },
       "source": [
         "#@markdown What is your Pennkey and pod? (text, not numbers, e.g. bfranklin)\n",
-        "my_pennkey = 'value' #@param {type:\"string\"}\n",
+        "my_pennkey = '' #@param {type:\"string\"}\n",
         "my_pod = 'Select' #@param ['Select', 'euclidean-wombat', 'sublime-newt', 'buoyant-unicorn', 'lackadaisical-manatee','indelible-stingray','superfluous-lyrebird','discreet-reindeer','quizzical-goldfish','ubiquitous-cheetah','nonchalant-crocodile','fashionable-lemur','spiffy-eagle','electric-emu','quotidian-lion','astute-jellyfish', 'quantum-herring']\n",
         "\n",
         "# start timing\n",
@@ -742,7 +742,7 @@
         "    else:\n",
         "        return (0, 0, 1, alpha) # Draw as blue\n",
         "\n",
-        "def win_statistics(agent1, agent2, games_per_side=100, n=8, bar_plot=True):\n",
+        "def win_statistics(agent1, agent2, games_per_side=100, bar_plot=True):\n",
         "    \"\"\"Play agent1 vs agent2 many times to get some statistics. At the end, show\n",
         "    statistics with a bar plot and return wins/draws/losses for agent1. Runs\n",
         "    'games_per_side' matches with agent1 as player 1 and another 'games_per_side'\n",
@@ -752,17 +752,17 @@
         "    Row 1 counts agent1 as player 2. Col 0 is wins for agent1, col 1 is draws,\n",
         "    and col 2 is losses\n",
         "    \"\"\"\n",
-        "    win_info = torch.zeros((2, 3))\n",
+        "    win_info = np.zeros((1, 3))\n",
         "    # Play agent1 as player 1\n",
-        "    outcome, _, _ = ai_vs_ai(agent1, agent2, n_games=games_per_side, n=n)\n",
+        "    outcome1, _, _ = ai_vs_ai(agent1, agent2, n_games=games_per_side//2, \n",
+        "                          n=6)\n",
+        "    # Play agent1 as player 2\n",
+        "    outcome2, _, _ = ai_vs_ai(agent2, agent1, n_games=games_per_side//2, \n",
+        "                          n=6)\n",
+        "    outcome = torch.cat((outcome1,outcome2),dim=0) \n",
         "    for g in range(games_per_side):\n",
         "        col_idx = 1-outcome[g,0] # Map agent1 outcome (-1,0,1) to column index (2,1,0)\n",
         "        win_info[0, col_idx] += 1\n",
-        "    # Play agent1 as player 1\n",
-        "    outcome, _, _ = ai_vs_ai(agent2, agent1, n_games=games_per_side, n=n)\n",
-        "    for g in range(games_per_side):\n",
-        "        col_idx = 1-outcome[g,1] # Map agent1 outcome (-1,0,1) to column index (2,1,0)\n",
-        "        win_info[1, col_idx] += 1\n",
         "    # (Maybe) plot\n",
         "    if bar_plot:\n",
         "        # Approximate standard error in each probability estimate (it would be\n",
@@ -770,16 +770,15 @@
         "        # for each of win/draw/loss, but this is fine for a large # of games)\n",
         "        win_prob = win_info / games_per_side\n",
         "        win_se = np.sqrt(win_prob*(1-win_prob)/games_per_side)\n",
-        "        plt.figure()\n",
-        "        plt.bar([0,1], win_prob[:,0], yerr=win_se[:,0], color=outcome2color(1, 0.5), label=\"wins\")\n",
-        "        plt.bar([0,1], win_prob[:,1], yerr=win_se[:,1], bottom=win_prob[:,0], color=outcome2color(0, 0.5))\n",
-        "        plt.bar([0,1], win_prob[:,2], yerr=win_se[:,2], bottom=win_prob[:,:2].sum(axis=1), color=outcome2color(-1, 0.5))\n",
-        "        plt.xticks([0,1], [\"Player 1\", \"Player 2\"])\n",
+        "        plt.figure(figsize=(4,6))\n",
+        "        plt.bar([0], win_prob[:,0], yerr=win_se[:,0], color=outcome2color(1, .8), label=\"wins\")\n",
+        "        plt.bar([0], win_prob[:,1], yerr=win_se[:,1], bottom=win_prob[:,0], color=outcome2color(0, 0.8))\n",
+        "        plt.bar([0], win_prob[:,2], yerr=win_se[:,2], bottom=win_prob[:,:2].sum(axis=1), color=outcome2color(-1, 0.8))\n",
+        "        plt.xticks([])\n",
         "        plt.yticks(np.linspace(0,1,11))\n",
-        "        plt.xlabel(f\"{agent1.name} role\")\n",
-        "        plt.ylabel(f\"% outcomes for {agent1.name}\")\n",
+        "        plt.ylabel(\"Fraction games won\")\n",
         "        plt.title(f\"{agent1.name} vs {agent2.name}\")\n",
-        "        plt.legend([\"wins\", \"draws\", \"losses\"])\n",
+        "        plt.legend([f\"{agent1.name} wins\", \"draws\", f\"{agent1.name} loses\"])\n",
         "        plt.grid()\n",
         "        plt.show()\n",
         "    return win_info"
@@ -1298,7 +1297,7 @@
         "cellView": "form"
       },
       "source": [
-        "policy_strategy = '' #@param string"
+        "policy_strategy = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -1309,7 +1308,9 @@
         "id": "18HphilJOozw"
       },
       "source": [
-        "## Section 1.1: Making a policy agent"
+        "## Section 1.1: Making a policy agent\n",
+        "\n",
+        "_Time estimate: 30 minutes since start_"
       ]
     },
     {
@@ -1496,6 +1497,15 @@
       "source": [
         "---\n",
         "# Section 2: Moving beyond snap-judgments: planning and tree-search"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "g1a7Bwp0T_fk"
+      },
+      "source": [
+        "_Time estimate: 50 minutes since start_"
       ]
     },
     {
@@ -1828,7 +1838,7 @@
         "id": "0mzdOyHJGBrf"
       },
       "source": [
-        "**Student response:** Estimate how many boards can result after 3 full turns. (Think about valid moves). How many final board states are there for an 8x8 board? How many valid moves exist *on average* during the course of the game?"
+        "**Student response:** How many final board states are there for an 8x8 board? How many valid moves exist *on average* during the course of the game?"
       ]
     },
     {
@@ -1838,9 +1848,8 @@
         "cellView": "form"
       },
       "source": [
-        "three_turns_out = 0 #@param number\n",
-        "final_boards = 0 #@param number\n",
-        "average_valid_moves = 0 #@param number\n"
+        "final_boards = \"\" #@param {type:\"string\"}\n",
+        "average_valid_moves = \"\" #@param {type:\"string\"}\n"
       ],
       "execution_count": null,
       "outputs": []
@@ -1856,6 +1865,15 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fSvHVE0lUZY0"
+      },
+      "source": [
+        "_Time estimate: 65 minutes since start_"
+      ]
+    },
+    {
       "cell_type": "code",
       "metadata": {
         "id": "uxPAqfnW06ar",
@@ -1864,7 +1882,7 @@
       "source": [
         "#@title Video: Monte Carlo Tree Search (MCTS)\n",
         "\n",
-        "param_list = ['three_turns_out', 'final_boards', 'average_valid_moves']\n",
+        "param_list = ['final_boards', 'average_valid_moves']\n",
         "for param in param_list:\n",
         "    if param not in locals():\n",
         "        raise NameError(\"Please make sure to run the cell \"\n",
@@ -1943,7 +1961,7 @@
         "id": "5O5BrGLJ3blG"
       },
       "source": [
-        "Before we dig into the code, let's examine correct behavior starting from the root node. We'll need a policy and value function of the boards, of course. Let's choose a simple one: a uniform policy, and a value that is randomly 0 or 1."
+        "Before we dig into the code, let's examine correct behavior starting from the root node. We'll need a policy and value function of the boards, of course. Let's choose a simple one: a uniform policy, and a value that is the simple `my_board_value` we defined above (fraction of the total pieces that are `whoami`)."
       ]
     },
     {
@@ -1954,20 +1972,11 @@
       "source": [
         "def random_policy_value_fun(boards:torch.Tensor, whoami:torch.Tensor):\n",
         "    pol = torch.ones_like(boards)\n",
-        "    val = torch.bernoulli(torch.ones_like(boards[:,0,0])/2.)\n",
+        "    val = my_board_value(boards, whoami)\n",
         "    return pol, val"
       ],
       "execution_count": null,
       "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "B4dTvIv62bOT"
-      },
-      "source": [
-        "Of course, this makes a terrible and essentially random Othello player, but it will help to understand how MCTS works. Where we are going later - the AlphaZero algorithm - is to create an agent who uses MCTS for planning, where the policy and the value are both provided by neural networks."
-      ]
     },
     {
       "cell_type": "markdown",
@@ -1977,9 +1986,7 @@
       "source": [
         "### The first 5 searches\n",
         "\n",
-        "We've built an `MCTSTree` class for you so we can see these trees. We haven't taken the fun away from you, don't worry! You'll build parts of it yourself soon.\n",
-        "\n",
-        "`MCTSTree` takes a value/policy function and a number of searches – how many times we send sap up to expand a node into new leaves."
+        "We've built an `MCTSTree` class for you so we can see these trees. `MCTSTree` takes a value/policy function and a number of searches – how many times we send sap up to expand a node into new leaves."
       ]
     },
     {
@@ -2012,7 +2019,7 @@
         "cellView": "form"
       },
       "source": [
-        "sum_to_4 = \"\" #@param string"
+        "sum_to_4 = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -2033,7 +2040,7 @@
         "cellView": "form"
       },
       "source": [
-        "sign_of_q = \"\" #@param string"
+        "sign_of_q = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -2109,7 +2116,7 @@
         "cellView": "form"
       },
       "source": [
-        "visit_counts_meaning = '' #@param string"
+        "visit_counts_meaning = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -2121,6 +2128,15 @@
       },
       "source": [
         "## Section 3.3: The effect of a policy\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "foSxbu-ugQI7"
+      },
+      "source": [
+        "_Time estimate: 80 minutes from start_"
       ]
     },
     {
@@ -2151,7 +2167,7 @@
         "id": "qVr_orGPR7SU"
       },
       "source": [
-        "Before, our `random_policy_value_fun` had a uniform policy, and all exploration was driven by value. Let's try the opposite. Here's a policy that really likes some directions over others. "
+        "Before, our `random_policy_value_fun` had a uniform policy, and all exploration was driven by value. Let's try the opposite. We'll use an uninformative value function (always zeros) and policy that really likes some directions over others. "
       ]
     },
     {
@@ -2162,7 +2178,7 @@
       "source": [
         "def nonuniform_policy_value_fun(boards:torch.Tensor, whoami:torch.Tensor):\n",
         "    pol = torch.bernoulli(torch.ones_like(boards)/2.) + 1e-6\n",
-        "    val = torch.ones_like(boards[:,0,0])\n",
+        "    val = torch.zeros_like(boards[:,0,0])\n",
         "    return pol, val"
       ],
       "execution_count": null,
@@ -2250,7 +2266,7 @@
         "cellView": "form"
       },
       "source": [
-        "effect_of_cpuct = '' #@param string"
+        "effect_of_cpuct = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -2262,6 +2278,15 @@
       },
       "source": [
         "## Section 3.5: Selecting a move for actual gameplay"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DRE1Ceh1U5i3"
+      },
+      "source": [
+        "_Time estimate: 90 minutes since start. This next Exercise 3 should take 30 minutes for the tutorial to end on time._"
       ]
     },
     {
@@ -2317,7 +2342,7 @@
         "cellView": "form"
       },
       "source": [
-        "action_selection_strategy = '' #@param string"
+        "action_selection_strategy = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -2561,6 +2586,15 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "bYSowRotVgeQ"
+      },
+      "source": [
+        "_Time estimate: 120 minutes since start._"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "WeywcYYMWuZE"
       },
       "source": [
@@ -2612,7 +2646,7 @@
         "cellView": "form"
       },
       "source": [
-        "search_scaling = '' #@param string"
+        "search_scaling = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -2635,7 +2669,7 @@
         "cellView": "form"
       },
       "source": [
-        "train_time_bound = '' #@param string"
+        "train_time_bound = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -2677,7 +2711,7 @@
         "cellView": "form"
       },
       "source": [
-        "adjusted_train_time_bound = '' #@param string"
+        "adjusted_train_time_bound = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -2734,7 +2768,9 @@
       },
       "source": [
         "---\n",
-        "# Section 5: Parallel MCTS"
+        "# Section 5: Parallel MCTS\n",
+        "\n",
+        "_Time estimate: 130 minutes from start_"
       ]
     },
     {
@@ -3370,7 +3406,7 @@
         "cellView": "form"
       },
       "source": [
-        "why_tree_search_parallelization_hard = '' #@param string"
+        "why_tree_search_parallelization_hard = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -3624,7 +3660,7 @@
         "cellView": "form"
       },
       "source": [
-        "why_flip_perspective = '' #@param string"
+        "why_flip_perspective = '' #@param {type:\"string\"}"
       ],
       "execution_count": null,
       "outputs": []
@@ -3895,19 +3931,20 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "fC2gXPxx1I9_",
-        "cellView": "form"
+        "id": "fC2gXPxx1I9_"
       },
       "source": [
-        "#@markdown (RUN ME) See alignment of policy to MCTS visit counts\n",
-        "pol_val_net.eval()\n",
-        "alpha_zero_agent = MCTSagent_from_net(pol_val_net, n, 100, 20)\n",
-        "alpha_zero_agent.temperature = 0.1\n",
-        "outcomes, raw_states, raw_mcts_counts = ai_vs_ai(alpha_zero_agent, n_games=100,\n",
-        "                                                 n=n, callback=mcts_visits_callback)\n",
+        "#markdown (RUN ME) See alignment of policy to MCTS visit counts in a test game\n",
+        "# pol_val_net.eval()\n",
+        "# alpha_zero_agent = MCTSagent_from_net(pol_val_net, n, 100, 20)\n",
+        "# alpha_zero_agent.temperature = 0.1\n",
+        "# outcomes, raw_states, raw_mcts_counts = ai_vs_ai(alpha_zero_agent, n_games=100,\n",
+        "#                                                  n=n, callback=mcts_visits_callback)\n",
         "\n",
         "plt.figure(figsize=(10,5))\n",
         "ax1, ax2 = plt.subplot(1,2,1), plt.subplot(1,2,2)\n",
+        "policy_targets = []\n",
+        "policy_pred = []\n",
         "for t in range(len(raw_states)):\n",
         "    sgn = +1 if t % 2 == 0 else -1\n",
         "    player = 1 if t % 2 == 0 else 2\n",
@@ -3915,10 +3952,17 @@
         "    counts_t = raw_mcts_counts[t].view(-1, n*n)\n",
         "    targets_t = counts_t / counts_t.sum(dim=1, keepdim=True)\n",
         "    valid = ~torch.any(torch.isnan(raw_states[t][:,0,0]))\n",
-        "    ax1.scatter(targets_t[valid,...].cpu().T, pol_pred[valid,...].detach().exp().view(-1, n*n).cpu().T, marker='.')\n",
-        "    for g in range(len(raw_states)):\n",
-        "        if not torch.isnan(raw_states[t][g,0,0]):\n",
-        "            ax2.plot(t, +val_pred[g].item(), marker='.', color=outcome2color(outcomes[g,player-1], 0.25))\n",
+        "    policy_targets += list(targets_t[valid,...].cpu().T)\n",
+        "    policy_pred += list(pol_pred[valid,...].detach().exp().view(-1, n*n).cpu().T)\n",
+        "\n",
+        "ax1.scatter(policy_targets, policy_pred,\n",
+        "            marker='.', alpha = .5)\n",
+        "    # for g in range(len(raw_states)):\n",
+        "    #     if not torch.isnan(raw_states[t][g,0,0]):\n",
+        "    #         ax2.plot(t, val_pred[g].item(), marker='.', \n",
+        "    #                  color=outcome2color(outcomes[g,player-1], 0.25),\n",
+        "    #                  alpha = .2)\n",
+        "    #     break\n",
         "            # ax2.plot(t, -val_pred[g].item(), marker='.', color=outcome2color(outcomes[g,2-player], 0.25))\n",
         "ax1.set_xlabel('normalized MCTS visit counts')\n",
         "ax1.set_ylabel('policy net output')\n",
@@ -3927,6 +3971,17 @@
         "ax2.set_ylabel('Value Net Output')\n",
         "ax2.set_title('Value Net Predictions')\n",
         "plt.show()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "s8s9_YJ3MS7V"
+      },
+      "source": [
+        "targets_t[valid,...].cpu().T"
       ],
       "execution_count": null,
       "outputs": []
@@ -4048,8 +4103,6 @@
         "except NameError: policy_strategy = \"\"\n",
         "try: how_to_train_policy;\n",
         "except NameError: how_to_train_policy = \"\"\n",
-        "try: three_turns_out;\n",
-        "except NameError: three_turns_out = 0\n",
         "try: final_boards;\n",
         "except NameError: final_boards = 0\n",
         "try: average_valid_moves;\n",
@@ -4075,14 +4128,12 @@
         "try: why_flip_perspective;\n",
         "except NameError: why_flip_perspective = \"\"\n",
         "\n",
-        "times = np.array([t1,t2,t3,t4,t5,t6,t7])-t0\n",
-        "\n",
+        "times = [(t-t0) for t in [t1,t2,t3,t4,t5,t6,t7]]\n",
         "\n",
         "fields = {\"pennkey\": my_pennkey,\n",
         "          \"pod\": my_pod,\n",
         "          \"policy_strategy\": policy_strategy,\n",
         "          \"how_to_train_policy\": how_to_train_policy,\n",
-        "          \"three_turns_out\": three_turns_out,\n",
         "          \"final_boards\": final_boards,\n",
         "          \"average_valid_moves\": average_valid_moves,\n",
         "          \"sum_to_4\": sum_to_4,\n",
@@ -4136,7 +4187,9 @@
       "source": [
         "## Homework: \n",
         "\n",
-        "Complete the following assignment: https://colab.research.google.com/github/CIS-522/course-content/blob/main/tutorials/W1_AlphaZero/student/W1_Homework.ipynb"
+        "Complete the following assignment: https://colab.research.google.com/github/CIS-522/course-content/blob/main/tutorials/W1_AlphaZero/student/W1_Homework.ipynb\n",
+        "\n",
+        "This is due 1 week from today at the start of next week's Tutorial 2."
       ]
     }
   ]


### PR DESCRIPTION
This includes:
- using the old value function in exploring MCTS instead of introducing a new one
- time estimates included at section headers
- opacity in 6.3
- switching all answer boxes to unformatted plain text
- like T1, `win_statistics` now just shows the average wins when who gets to play first is shuffled 
- removed the response asking to estimate # of moves 3 turns out