### PR TITLE
Fix IndexError in Part 3

### DIFF
--- a/tutorials/W6_ConvNets/W6_Homework.ipynb
+++ b/tutorials/W6_ConvNets/W6_Homework.ipynb
@@ -6,7 +6,9 @@
     "colab": {
       "name": "W6_Homework.ipynb",
       "provenance": [],
-      "collapsed_sections": []
+      "collapsed_sections": [],
+      "toc_visible": true,
+      "include_colab_link": true
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -14,6 +16,16 @@
     }
   },
   "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/CIS-522/course-content/blob/W6_hw/tutorials/W6_ConvNets/W6_Homework.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
     {
       "cell_type": "markdown",
       "metadata": {
@@ -871,22 +883,19 @@
       "source": [
         "dataiter = iter(trainloader)\n",
         "images, labels = dataiter.next()\n",
-        "input_img=images[random.randrange(0,63,1)].unsqueeze(0)\n",
+        "input_img=images[random.randrange(0,BATCH_SIZE,1)].unsqueeze(0)\n",
         "img_original=input_img.squeeze().permute(1,2,0).numpy()\n",
-        "\n",
         "\n",
         "Layer_Name= 5 #@param {type:\"slider\", min:1, max:54, step:1}\n",
         "Layer_Name=str(Layer_Name)\n",
-        "Num_Filters = 40 #@param {type:\"slider\", min:8, max:64, step:8}\n",
+        "Num_Filters = 64 #@param {type:\"slider\", min:8, max:64, step:8}\n",
         "from skimage.transform import resize\n",
         "import matplotlib.pyplot as plt\n",
         "def temp_rem(model,key,input_img):\n",
         "    model.eval()\n",
         "    flag=0\n",
         "    alt_=[]    \n",
-        "    #print(model._modules.keys())\n",
         "    for search in model._modules['features']._modules.keys():\n",
-        "        #print(search,key)\n",
         "        if flag==1:\n",
         "            break\n",
         "        if key==search:\n",
@@ -896,11 +905,13 @@
         "\n",
         "def plot(data,Num_Filters,img_original):\n",
         "    import matplotlib.pyplot as plt\n",
+        "    \n",
+        "    # Scale pixel values to between 0 and 1 for plotting\n",
+        "    img_original = (img_original + 1) / 2\n",
         "    i=0\n",
         "    flag=0\n",
         "    if len(data)==3:\n",
         "        fig, ax = plt.subplots(nrows=1, ncols=4)\n",
-        "\n",
         "        for col in ax:\n",
         "            if flag==0:\n",
         "                col.imshow(resize(img_original,(256,256)))    \n",
@@ -922,13 +933,11 @@
         "                    col.imshow(resize(img_original,(256,256)))    \n",
         "                    col.set_xticklabels([])\n",
         "                    col.set_yticklabels([])\n",
-        "                    #col.set_aspect('equal')\n",
         "                    flag=1\n",
         "                else:\n",
         "                    col.imshow(resize(data[i],(256,256)))\n",
         "                    col.set_xticklabels([])\n",
         "                    col.set_yticklabels([])\n",
-        "                    #col.set_aspect('equal')\n",
         "                i=i+1\n",
         "        \n",
         "        \n",
@@ -936,15 +945,10 @@
         "        plt.tight_layout()\n",
         "        plt.subplots_adjust(wspace=0, hspace=0)\n",
         "        plt.show()\n",
-        "    \n",
         "\n",
-        "#print(\"Named Blocks in ResNet50 {}\".format(model._modules.keys()))\n",
-        "# import torchvision.models as m\n",
-        "# model=m.vgg19_bn(pretrained=True)\n",
         "model = net2\n",
         "plot(temp_rem(model,Layer_Name,input_img),Num_Filters,img_original)\n",
-        "#print(temp_rem(model,Layer_Name,input_img).shape)\n",
-        "plt.show()\n"
+        "plt.show()"
       ],
       "execution_count": null,
       "outputs": [


### PR DESCRIPTION
Currently the kernel visualizer assumes that the students are using a batch size of at least 64, and nondeterministically throws IndexErrors otherwise. See this post for the bug in the wild: https://cis522students.slack.com/archives/C01Q3QQBN2H/p1614987151002400

Changes:
- Sets the max index for the image used to `BATCH_SIZE`
- Scales the outputs to between 0 and 1 before running `plt.imshow` to avoid clipping