### PR TITLE
fix typo in quiz question in w2d2 notebook

### DIFF
--- a/W02_DLN/students/CIS_522_W2D2_Tutorial_–_Student_Version.ipynb
+++ b/W02_DLN/students/CIS_522_W2D2_Tutorial_–_Student_Version.ipynb
@@ -2829,7 +2829,7 @@
       },
       "outputs": [],
       "source": [
-        "# @markdown Go back to the crazy scheduling plot in Section 4. Can you give a value at which the nonlinearity kicks-in?\n",
+        "# @markdown Go back to the crazy scaling plot in Section 4. Can you give a value at which the nonlinearity kicks-in?\n",
         "xor = \"\"  # @param {type:\"string\"}\n"
       ]
     },


### PR DESCRIPTION
Fix the typo in the third quiz question in the W2D2 notebook.

Change 'scheduling plot' to 'scaling plot'.