### PR TITLE
fix to avoid issue of plotting with tensor in w4d2 notebook

### DIFF
--- a/W04_Regularization_Optimization/students/W4D2.ipynb
+++ b/W04_Regularization_Optimization/students/W4D2.ipynb
@@ -643,6 +643,7 @@
    ],
    "source": [
     "# @title Frobenious norm of the model\n",
+    "model_norm = [n.detach() if isinstance(n, torch.Tensor) else n for n in model_norm]\n",
     "plt.plot(model_norm)\n",
     "plt.ylabel(\"norm of the model\")\n",
     "plt.xlabel(\"epochs\")\n",
@@ -1092,6 +1093,7 @@
    ],
    "source": [
     "#@title Plot model weights with epoch\n",
+    "model_norm_dp = [n.detach() if isinstance(n, torch.Tensor) else n for n in model_norm_dp]\n",
     "plt.plot(model_norm_dp,label = 'dropout')\n",
     "plt.plot(model_norm,label = 'no dropout')\n",
     "plt.ylabel('norm of the model')\n",


### PR DESCRIPTION
In the `calculate_frobenius_norm` function, if students use torch for calculations, the returned result could be a tensor.

The fix makes sure tensors are detached before plotting.