### PR TITLE
W7D2: Fixed dataiter

### DIFF
--- a/W07_ModernConvNets_TL/students/CIS_522_W7D2_Tutorial_–_Student_Version.ipynb
+++ b/W07_ModernConvNets_TL/students/CIS_522_W7D2_Tutorial_–_Student_Version.ipynb
@@ -374,7 +374,7 @@
         "                                          shuffle=False)\n",
         "\n",
         "dataiter = iter(face_loader)\n",
-        "images, labels = dataiter.next()\n",
+        "images, labels = next(dataiter)\n",
         "\n",
         "# Show images\n",
         "plt.figure(figsize=(15, 15))\n",


### PR DESCRIPTION
The following changes have been made to W7D2:
- Changed dataiter.next() to next(dataiter)