### PR TITLE
fixed assert statement in w8d1 notebook

### DIFF
--- a/W08_Generative_Vision/students/CIS_522_W8D1_Tutorial.ipynb
+++ b/W08_Generative_Vision/students/CIS_522_W8D1_Tutorial.ipynb
@@ -1251,7 +1251,7 @@
         "\n",
         "# Uncomment to test your solution\n",
         "# conv_ae = ConvAutoEncoder(K=K)\n",
-        "# assert conv_ae.encoder(my_dataset[0][0].unsqueeze(0)).numel() == K, \\\n",
+        "# assert conv_ae.encode(my_dataset[0][0].unsqueeze(0)).numel() == K, \\\n",
         "#     \"Encoder output size should be K!\"\n",
         "# conv_losses = train_autoencoder(conv_ae, my_dataset)\n",
         "# plt.figure()\n",


### PR DESCRIPTION
The `ConvAutoEncoder` class has an `encode` method, but in the assert statement, it is called as `encoder`.