### PR TITLE
W9D1: Fix for error in importing PCA from sklearn.decomposition

### DIFF
--- a/W09_Text_and_Embedding/students/CIS_522_W9D1_Tutorial.ipynb
+++ b/W09_Text_and_Embedding/students/CIS_522_W9D1_Tutorial.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install -U datatops==0.2.2 gensim==4.3.1 matplotlib==3.7.1 matplotlib-inline==0.1.3 numpy==1.24.2 requests==2.28.2 requests-oauthlib==1.3.0 scikit-learn==1.2.2 vibecheck==0.0.3 > /dev/null 2>&1"
+    "!pip3 install -U datatops==0.2.2 gensim==4.3.1 matplotlib==3.7.1 matplotlib-inline==0.1.3 numpy==1.22.4 requests==2.28.2 requests-oauthlib==1.3.0 scikit-learn==1.2.2 vibecheck==0.0.3 > /dev/null 2>&1"
    ]
   },
   {


### PR DESCRIPTION
There is an error with the line ```from sklearn.decomposition import PCA``` probably owing to version incompatibility issues with numpy. Changing the numpy version in the first line of the notebook to ```numpy==1.22.4``` (which was the default version for my Colab) seems to fix the issue. The error is shown below.

```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
RuntimeError: module compiled against API version 0x10 but this version of numpy is 0xf . Check the section C-API incompatibility at the Troubleshooting ImportError section at https://numpy.org/devdocs/user/troubleshooting-importerror.html#c-api-incompatibility for indications on how to solve this problem .
SEARCH STACK OVERFLOW
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
[<ipython-input-20-fea2fde7ffe3>](https://localhost:8080/#) in <module>
      1 from matplotlib import pyplot as plt
----> 2 from sklearn.decomposition import PCA
      3 
      4 embedding_2d = PCA(n_components=2).fit_transform(embedding)
      5 



7 frames

[/usr/local/lib/python3.9/dist-packages/numpy/testing/_private/utils.py](https://localhost:8080/#) in <module>
     21 from numpy.core import(
     22      intp, float32, empty, arange, array_repr, ndarray, isnat, array)
---> 23 import numpy.linalg.lapack_lite
     24 
     25 from io import StringIO

ImportError: numpy.core.multiarray failed to import
---------------------------------------------------------------------------
NOTE: If your import is failing due to a missing package, you can
manually install dependencies using either !pip or !apt.

To view examples of installing some common dependencies, click the
"Open Examples" button below.
```