### PR TITLE
W10D2: Suggested fix for numpy version issue

### DIFF
--- a/W10_NLP/students/CIS_522_W10D2_Tutorial.ipynb
+++ b/W10_NLP/students/CIS_522_W10D2_Tutorial.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install -U numpy datasets transformers evaluate datatops==0.2.2 vibecheck==0.0.3 > /dev/null 2>&1"
+    "!pip3 install -U numpy==1.22.4 datasets transformers evaluate datatops==0.2.2 vibecheck==0.0.3 > /dev/null 2>&1"
    ]
   },
   {


### PR DESCRIPTION
Currently, executing the code 
```
from transformers import AutoModelWithLMHead
from transformers import pipeline

model = AutoModelWithLMHead.from_pretrained("codeparrot/codeparrot-small")
generation_pipeline = pipeline(
    "text-generation", # The task to run. This tells hf what the pipeline steps are
    model=model, # The model to use; can also pass the string here;
    tokenizer=tokenizer, # The tokenizer to use; can also pass the string name here.
)
```
throws the error
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
RuntimeError: module compiled against API version 0x10 but this version of numpy is 0xf . Check the section C-API incompatibility at the Troubleshooting ImportError section at https://numpy.org/devdocs/user/troubleshooting-importerror.html#c-api-incompatibility for indications on how to solve this problem .
SEARCH STACK OVERFLOW
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
[/usr/local/lib/python3.9/dist-packages/transformers/utils/import_utils.py](https://localhost:8080/#) in _get_module(self, module_name)
   1125         try:
-> 1126             return importlib.import_module("." + module_name, self.__name__)
   1127         except Exception as e:



25 frames

ImportError: numpy.core.multiarray failed to import
The above exception was the direct cause of the following exception:

RuntimeError                              Traceback (most recent call last)
[/usr/local/lib/python3.9/dist-packages/transformers/utils/import_utils.py](https://localhost:8080/#) in _get_module(self, module_name)
   1126             return importlib.import_module("." + module_name, self.__name__)
   1127         except Exception as e:
-> 1128             raise RuntimeError(
   1129                 f"Failed to import {self.__name__}.{module_name} because of the following error (look up to see its"
   1130                 f" traceback):\n{e}"

RuntimeError: Failed to import transformers.pipelines because of the following error (look up to see its traceback):
numpy.core.multiarray failed to import
```
Changing the numpy version in the first cell of the notebook to ```numpy==1.22.4``` seems to resolve the issue.